### PR TITLE
:memo: fix typos in README.md

### DIFF
--- a/README.md
+++ b/README.md
@@ -49,7 +49,7 @@ Options:
   -V, --version                  Print version
 ```
 
-**swawytreesave load --help**
+**swaytreesave load --help**
 
 ```txt
 Usage: swaytreesave load [OPTIONS]
@@ -64,13 +64,13 @@ Options:
 Saves the current tree to `$HOME/.config/swaytreesave/default.yaml`:
 
 ```bash
-swawytreesave save
+swaytreesave save
 ```
 
 Loads the default tree back:
 
 ```bash
-swawytreesave load
+swaytreesave load
 ```
 
 ### Sway config example


### PR DESCRIPTION
Hello!

While trying to test this package, I've copied examples from README, but they didn't work. This should fix that case.